### PR TITLE
add publicPath and allow .babelrc config options in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,9 @@ A subset of the module features can be configured directly through the `react-sc
         "logLevel": "debug"
       }
     }
-  }
+  },
+ "publicPath": "./my-folder/" //default to "/",
+ "allowBabelrc": true // default to false
 }
 ```
 

--- a/config/constants.js
+++ b/config/constants.js
@@ -5,8 +5,9 @@ const BUILD = path.join(CWD, 'build');
 const CWD_NODE_MODULES = path.join(CWD, 'node_modules');
 const NODE_MODULES = path.join(__dirname, '../node_modules');
 const PACKAGE = require(path.join(CWD, 'package.json'));
-const APP_SRC_FILE = path.join(CWD, PACKAGE["react-scv"].appBuildEntry);
-const UMD_SRC_FILE = path.join(CWD, PACKAGE["react-scv"].umdBuildEntry);
+const REACT_PACKAGE_CONFIG = PACKAGE["react-scv"];
+const APP_SRC_FILE = path.join(CWD, REACT_PACKAGE_CONFIG.appBuildEntry);
+const UMD_SRC_FILE = path.join(CWD, REACT_PACKAGE_CONFIG.umdBuildEntry);
 const SRC_DIR = path.join(CWD, 'src');
 const RULES_INCLUDE = [SRC_DIR];
 const RULES_EXCLUDE = /(node_modules|bower_components)/;
@@ -23,5 +24,6 @@ module.exports = {
   SRC_DIR,
   RULES_INCLUDE,
   RULES_EXCLUDE,
-  DEV_SERVER
+  DEV_SERVER,
+  REACT_PACKAGE_CONFIG
 }

--- a/config/webpack.core.js
+++ b/config/webpack.core.js
@@ -3,29 +3,28 @@
 const DefinePlugin = require('webpack').DefinePlugin;
 const ProgressBarWebpackPlugin = require('progress-bar-webpack-plugin');
 const merge = require('webpack-merge');
-
 const {BUILD, CWD_NODE_MODULES, NODE_MODULES, RULES_EXCLUDE, RULES_INCLUDE, REACT_PACKAGE_CONFIG} = require('./constants');
-
 const allowBabelrc = REACT_PACKAGE_CONFIG.allowBabelrc || false
-const publicPath = REACT_PACKAGE_CONFIG.publicPath || '/'
 
 module.exports = function (config, cursors) {
 
   const ENV = Object
-  .keys(process.env)
-  .filter(key => key.toUpperCase().startsWith('NEO_'))
-  .reduce((env, key) => {
-    env[`process.env.${key}`] = JSON.stringify(process.env[key]);
-    return env;
-  }, {
-    'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
-  });
+    .keys(process.env)
+    .filter(key => key.toUpperCase().startsWith('NEO_'))
+    .reduce((env, key) => {
+      env[`process.env.${key}`] = JSON.stringify(process.env[key]);
+      return env;
+    }, {
+      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
+    });
+
+  const publicPath = process.env.NODE_ENV === 'production' ? REACT_PACKAGE_CONFIG.publicPath : '/';
 
   return merge(config, {
     output: {
       path: BUILD,
       filename: 'bundle.js',
-      publicPath: publicPath
+      publicPath
     },
     plugins: [
       cursors.push('define-plugin',

--- a/config/webpack.core.js
+++ b/config/webpack.core.js
@@ -4,7 +4,10 @@ const DefinePlugin = require('webpack').DefinePlugin;
 const ProgressBarWebpackPlugin = require('progress-bar-webpack-plugin');
 const merge = require('webpack-merge');
 
-const {BUILD, CWD_NODE_MODULES, NODE_MODULES, RULES_EXCLUDE, RULES_INCLUDE} = require('./constants');
+const {BUILD, CWD_NODE_MODULES, NODE_MODULES, RULES_EXCLUDE, RULES_INCLUDE, REACT_PACKAGE_CONFIG} = require('./constants');
+
+const allowBabelrc = REACT_PACKAGE_CONFIG.allowBabelrc || false
+const publicPath = REACT_PACKAGE_CONFIG.publicPath || '/'
 
 module.exports = function (config, cursors) {
 
@@ -22,7 +25,7 @@ module.exports = function (config, cursors) {
     output: {
       path: BUILD,
       filename: 'bundle.js',
-      publicPath: '/'
+      publicPath: publicPath
     },
     plugins: [
       cursors.push('define-plugin',
@@ -85,7 +88,7 @@ module.exports = function (config, cursors) {
             {
               loader: 'babel-loader',
               options: {
-                babelrc: false,
+                babelrc: allowBabelrc,
                 presets: [
                   ['@babel/preset-env', {"modules": false}], //{ "modules": false } is needed to make react-hot-loader work
                   '@babel/preset-stage-0',


### PR DESCRIPTION
Add two new config options in the react-scv block in package.json

```javascript
"react-scv": {
  [...],
  "publicPath": "./my-folder/" //default to "/",
  "allowBabelrc": true // default to false
}